### PR TITLE
Ping revamp

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -1060,6 +1060,22 @@ exports.categories = {
                 },
                 "regex": /event (?:(create) (.+) for (.+)|(delete) (.+)|(list)( .+)?)/i,
                 "experimental": false
+            },
+            "group": {
+                "display_names": ["group"],
+                "pretty_name": "Mention groups",
+                "short_description": "",
+                "description": "Manage groups of people that can be pinged collectively",
+                "syntax": "group (create|delete) {name} ({users})",
+                "example": ["group create testers me, Larry", "group delete testers", "group subscribe testers Anton", "group unsubscribe testers me"],
+                "sudo": false,
+                "attachments": false,
+                "user_input": {
+                    "accepts": false,
+                    "optional": false
+                },
+                "regex": /group (create|delete|subscribe|unsubscribe) ([^\s]+)(?: (.+))?/i,
+                "experimental": false
             }
         }
     }

--- a/src/config.js
+++ b/src/config.js
@@ -169,3 +169,6 @@ exports.reminderTime = 30;
 
 // User agent to use for scraping (impersonate Twitter and Facebook bots by default)
 exports.scrapeAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/601.2.4 (KHTML, like Gecko) Version/9.0.1 Safari/601.2.4 facebookexternalhit/1.1 Facebot Twitterbot/1.0";
+
+// Regex to match when mentioning the whole group (see the `mention` passive message type)
+exports.channelMentionRegex = /@@(all|everyone|channel)/i;

--- a/src/passive.js
+++ b/src/passive.js
@@ -123,7 +123,7 @@ function handleMention(match, groupInfo, messageObj) {
     const group = match[1].toLowerCase();
     const senderId = messageObj.senderID;
 
-    const members = groupInfo.groups[group];
+    const members = groupInfo.mentionGroups[group];
     if (members) {
         // Found a ping group to mention
         const mentions = members.map(id => {

--- a/src/passive.js
+++ b/src/passive.js
@@ -124,7 +124,6 @@ function handleMention(match, groupInfo, messageObj) {
     const body = messageObj.body;
     const senderId = messageObj.senderID;
 
-
     // Two types of mentions: channel-wide and stored groups
     const allMatch = body.match(config.channelMentionRegex);
     let members = groupInfo.mentionGroups[group];
@@ -132,7 +131,6 @@ function handleMention(match, groupInfo, messageObj) {
     if (allMatch) {
         // Alert everyone in the group
         members = Object.keys(groupInfo.names);
-
         // Remove sending user from recipients
         members.splice(members.indexOf(senderId), 1);
     }

--- a/src/passive.js
+++ b/src/passive.js
@@ -121,11 +121,24 @@ function handleWiki(match, groupInfo) {
 
 function handleMention(match, groupInfo, messageObj) {
     const group = match[1].toLowerCase();
+    const body = messageObj.body;
     const senderId = messageObj.senderID;
 
-    const members = groupInfo.mentionGroups[group];
+
+    // Two types of mentions: channel-wide and stored groups
+    const allMatch = body.match(config.channelMentionRegex);
+    let members = groupInfo.mentionGroups[group];
+
+    if (allMatch) {
+        // Alert everyone in the group
+        members = Object.keys(groupInfo.names);
+
+        // Remove sending user from recipients
+        members.splice(members.indexOf(senderId), 1);
+    }
+
     if (members) {
-        // Found a ping group to mention
+        // Found a group to mention (either stored or global)
         const mentions = members.map(id => {
             return {
                 "tag": `@${groupInfo.names[id]}`,
@@ -141,6 +154,6 @@ function handleMention(match, groupInfo, messageObj) {
         }
     } else {
         // Check for old-style individual pings
-        utils.handlePings(messageObj.body, senderId, groupInfo);
+        utils.handlePings(body, senderId, groupInfo);
     }
 }

--- a/src/passive.js
+++ b/src/passive.js
@@ -134,7 +134,11 @@ function handleMention(match, groupInfo, messageObj) {
         });
         const msg = mentions.map(mention => mention.tag).join(" ");
 
-        utils.sendMessageWithMentions(msg, mentions, groupInfo.threadId);
+        if (mentions.length > 0) {
+            utils.sendMessageWithMentions(msg, mentions, groupInfo.threadId);
+        } else {
+            utils.sendError("There are no members in that group.", groupInfo.threadId);
+        }
     } else {
         // Check for old-style individual pings
         utils.handlePings(messageObj.body, senderId, groupInfo);

--- a/src/runcommand.js
+++ b/src/runcommand.js
@@ -545,7 +545,7 @@ const funcs = {
                     time = reply.timestamp
                 }
                 const date = new Date(parseInt(time));
-                
+
                 if (name == "append") {
                     // -- Appending an existing pin --
                     // Need to extract existing pin name and content to append, which
@@ -860,7 +860,7 @@ const funcs = {
             }
         }
     },
-    "restart": (threadId, ) => {
+    "restart": (threadId,) => {
         utils.restart(() => {
             utils.sendMessage("Restarting...", threadId);
         });
@@ -1459,6 +1459,28 @@ const funcs = {
                 utils.sendMessage(msg, threadId);
             }
         });
+    },
+    "group": (threadId, cmatch, groupInfo, _, fromUserId) => {
+        const action = cmatch[1].toLowerCase();
+        const name = cmatch[2];
+        const userList = cmatch[3];
+
+        let userIds = [];
+        if (userList) {
+            const users = userList.split(",").map(m => utils.parseNameReplacements(m.toLowerCase().trim(), fromUserId, groupInfo));
+            userIds = users.map(user => groupInfo.members[user]).filter(id => id);
+            userIds = utils.pruneDuplicates(userIds);
+        }
+
+        if (action == "create") {
+            utils.createMentionGroup(name, userIds, groupInfo, threadId);
+        } else if (action == "subscribe" && userIds.length > 0) {
+            utils.addToMentionGroup(name, userIds, groupInfo, threadId);
+        } else if (action == "unsubscribe" && userIds.length > 0) {
+            utils.removeFromMentionGroup(name, userIds, groupInfo, threadId);
+        } else if (action == "delete") {
+            utils.deleteMentionGroup(name, groupInfo, threadId);
+        }
     }
 };
 

--- a/src/runcommand.js
+++ b/src/runcommand.js
@@ -1472,14 +1472,11 @@ const funcs = {
             userIds = utils.pruneDuplicates(userIds);
         }
 
-        if (action == "create") {
-            utils.createMentionGroup(name, userIds, groupInfo, threadId);
-        } else if (action == "subscribe" && userIds.length > 0) {
-            utils.addToMentionGroup(name, userIds, groupInfo, threadId);
-        } else if (action == "unsubscribe" && userIds.length > 0) {
-            utils.removeFromMentionGroup(name, userIds, groupInfo, threadId);
-        } else if (action == "delete") {
-            utils.deleteMentionGroup(name, groupInfo, threadId);
+        switch (action) {
+            case "create": utils.createMentionGroup(name, userIds, groupInfo); break;
+            case "subscribe": utils.subToMentionGroup(name, userIds, groupInfo); break;
+            case "unsubscribe": utils.unsubFromMentionGroup(name, userIds, groupInfo); break;
+            case "delete": utils.deleteMentionGroup(name, groupInfo); break;
         }
     }
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1582,7 +1582,7 @@ exports.setGroupPropertyAndHandleErrors = (property, groupInfo, errMsg, successM
     });
 }
 
-exports.createMentionGroup = (name, userIds, groupInfo, threadId) => {
+exports.createMentionGroup = (name, userIds, groupInfo) => {
     groupInfo.mentionGroups[name] = userIds;
 
     const memberNames = userIds.map(user => groupInfo.names[user]).join("/");
@@ -1594,7 +1594,7 @@ exports.createMentionGroup = (name, userIds, groupInfo, threadId) => {
     );
 }
 
-exports.deleteMentionGroup = (name, groupInfo, threadId) => {
+exports.deleteMentionGroup = (name, groupInfo) => {
     delete groupInfo.mentionGroups[name];
 
     exports.setGroupPropertyAndHandleErrors("mentionGroups", groupInfo,
@@ -1603,7 +1603,9 @@ exports.deleteMentionGroup = (name, groupInfo, threadId) => {
     );
 }
 
-exports.addToMentionGroup = (name, userIds, groupInfo, threadId) => {
+exports.subToMentionGroup = (name, userIds, groupInfo) => {
+    if (userIds.length < 1) { return; }
+
     let members = groupInfo.mentionGroups[name];
     if (members) {
         members = members.concat(userIds);
@@ -1611,15 +1613,17 @@ exports.addToMentionGroup = (name, userIds, groupInfo, threadId) => {
 
         const memberNames = userIds.map(user => groupInfo.names[user]).join("/");
         exports.setGroupPropertyAndHandleErrors("mentionGroups", groupInfo,
-            "Unable to add to the group.",
-            `Successfully added ${memberNames} to group "${name}".`
+            "Unable to subscribe to the group.",
+            `${memberNames} successfully subscribed to group "${name}".`
         );
     } else {
         exports.sendError("Please provide a valid group to add members.")
     }
 }
 
-exports.removeFromMentionGroup = (name, userIds, groupInfo, threadId) => {
+exports.unsubFromMentionGroup = (name, userIds, groupInfo) => {
+    if (userIds.length < 1) { return; }
+
     let members = groupInfo.mentionGroups[name];
     if (members) {
         members = members.filter(id => !userIds.includes(id));
@@ -1627,8 +1631,8 @@ exports.removeFromMentionGroup = (name, userIds, groupInfo, threadId) => {
 
         const memberNames = userIds.map(user => groupInfo.names[user]).join("/");
         exports.setGroupPropertyAndHandleErrors("mentionGroups", groupInfo,
-            "Unable to remove from the group.",
-            `Successfully removed ${memberNames} from group "${name}".`
+            "Unable to unsubscribe from the group.",
+            `${memberNames} successfully unsubscribed from group "${name}".`
         );
     } else {
         exports.sendError("Please provide a valid group to remove members.")

--- a/src/utils.js
+++ b/src/utils.js
@@ -1514,30 +1514,23 @@ exports.getStockData = (symbol, callback) => {
 // and extracts the intended users from the ping to send the message to them
 exports.parsePing = (m, fromUserId, groupInfo) => {
     let users = [];
-    const allMatch = m.match(/@@(all|everyone|channel)/i);
-    if (allMatch && allMatch[1]) { // Alert everyone
-        users = Object.keys(groupInfo.members);
-        // Remove sending user from recipients
-        users.splice(users.indexOf(groupInfo.names[fromUserId].toLowerCase()), 1);
-        m = m.split("@@" + allMatch[1]).join("");
-    } else {
-        let matches = exports.matchesWithUser(new RegExp("@@"), m, fromUserId, groupInfo, false, "");
-        while (matches && matches[1]) {
-            const match = matches[1];
-            users.push(match.toLowerCase());
-            const beforeSplit = m;
-            m = m.split(`@@${match}`).join(""); // Remove discovered match from string
-            if (m == beforeSplit) { // Discovered match was "me" or alias
-                m = m.split("@@me").join("");
-                const alias = groupInfo.aliases[match];
-                if (alias) {
-                    m = m.split(`@@${alias}`).join("");
-                }
+
+    let matches = exports.matchesWithUser(new RegExp("@@"), m, fromUserId, groupInfo, false, "");
+    while (matches && matches[1]) {
+        const match = matches[1];
+        users.push(match.toLowerCase());
+        const beforeSplit = m;
+        m = m.split(`@@${match}`).join(""); // Remove discovered match from string
+        if (m == beforeSplit) { // Discovered match was "me" or alias
+            m = m.split("@@me").join("");
+            const alias = groupInfo.aliases[match];
+            if (alias) {
+                m = m.split(`@@${alias}`).join("");
             }
-            matches = exports.matchesWithUser(new RegExp("@@"), m, fromUserId, groupInfo, false, "");
         }
-        // After loop, m will contain the message without the pings (the message to be sent)
+        matches = exports.matchesWithUser(new RegExp("@@"), m, fromUserId, groupInfo, false, "");
     }
+    // After loop, m will contain the message without the pings (the message to be sent)
     return {
         /* Return array of names to ping, but remove sending user */
         "users": users.filter(e => (e != groupInfo.names[fromUserId].toLowerCase())),

--- a/src/utils.js
+++ b/src/utils.js
@@ -1543,3 +1543,29 @@ exports.parsePing = (m, fromUserId, groupInfo) => {
         "message": m.trim() // Remove leading/trailing whitespace
     };
 }
+
+// Ping individual users or the entire group
+exports.handlePings = (body, senderId, info) => {
+    const pingData = exports.parsePing(body, senderId, info);
+    const pingUsers = pingData.users;
+    const pingMessage = pingData.message;
+
+    if (pingUsers) {
+        for (let i = 0; i < pingUsers.length; i++) {
+            const sender = info.nicknames[senderId] || info.names[senderId] || "A user";
+            let message = `${sender} summoned you in ${info.name}`;
+            if (pingMessage.length > 0) { // Message left after pings removed – pass to receiver
+                message = `"${pingMessage}" – ${sender} in ${info.name}`;
+            }
+            message += ` at ${exports.getTimeString()}` // Time stamp
+            // Send message with links to chat/sender
+            exports.sendMessageWithMentions(message, [{
+                "tag": sender,
+                "id": senderId
+            }, {
+                "tag": info.name,
+                "id": info.threadId
+            }], info.members[pingUsers[i]]);
+        }
+    }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -281,6 +281,7 @@ exports.updateGroupInfo = (threadId, message, callback = () => { }, api = gapi) 
                             info.aliases = {};
                             info.pinned = {};
                             info.events = {};
+                            info.mentionGroups = {};
                             info.isGroup = data.isGroup;
                         }
                         api.getUserInfo(data.participantIDs, (err, userData) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1579,7 +1579,7 @@ exports.createMentionGroup = (name, userIds, groupInfo) => {
     groupInfo.mentionGroups[name] = userIds;
 
     const memberNames = userIds.map(user => groupInfo.names[user]).join("/");
-    const memberString = userIds.length > 0 ? ` with members ${memberNames}` : "";
+    const memberString = userIds.length > 0 ? ` with member${userIds.length == 1 ? "" : "s"} ${memberNames}` : "";
 
     exports.setGroupPropertyAndHandleErrors("mentionGroups", groupInfo,
         "Unable to create the group.",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1508,3 +1508,38 @@ exports.getStockData = (symbol, callback) => {
         });
     })
 }
+
+// Parses a sent message for pings, removes them from the message,
+// and extracts the intended users from the ping to send the message to them
+exports.parsePing = (m, fromUserId, groupInfo) => {
+    let users = [];
+    const allMatch = m.match(/@@(all|everyone|channel)/i);
+    if (allMatch && allMatch[1]) { // Alert everyone
+        users = Object.keys(groupInfo.members);
+        // Remove sending user from recipients
+        users.splice(users.indexOf(groupInfo.names[fromUserId].toLowerCase()), 1);
+        m = m.split("@@" + allMatch[1]).join("");
+    } else {
+        let matches = exports.matchesWithUser(new RegExp("@@"), m, fromUserId, groupInfo, false, "");
+        while (matches && matches[1]) {
+            const match = matches[1];
+            users.push(match.toLowerCase());
+            const beforeSplit = m;
+            m = m.split(`@@${match}`).join(""); // Remove discovered match from string
+            if (m == beforeSplit) { // Discovered match was "me" or alias
+                m = m.split("@@me").join("");
+                const alias = groupInfo.aliases[match];
+                if (alias) {
+                    m = m.split(`@@${alias}`).join("");
+                }
+            }
+            matches = exports.matchesWithUser(new RegExp("@@"), m, fromUserId, groupInfo, false, "");
+        }
+        // After loop, m will contain the message without the pings (the message to be sent)
+    }
+    return {
+        /* Return array of names to ping, but remove sending user */
+        "users": users.filter(e => (e != groupInfo.names[fromUserId].toLowerCase())),
+        "message": m.trim() // Remove leading/trailing whitespace
+    };
+}


### PR DESCRIPTION
- Revamp pings to use new passive message types system in `passive.js`
- Add new type of ping that uses native mentions instead of PMs
- Create new group command and subcommands to create & manage mention groups that can all be pinged at once
- Migrate @@all/channel/everyone global mention commands to the new system to give all chats these groups for free
- Use old PM ping system as a fallback, now located in `utils.js` instead of `main.js`